### PR TITLE
Correct version to 1.0.0

### DIFF
--- a/puppet-lint-exec_idempotency-check.gemspec
+++ b/puppet-lint-exec_idempotency-check.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-exec_idempotency-check'
-  spec.version     = '2.0.0'
+  spec.version     = '1.0.0'
   spec.homepage    = 'https://github.com/voxpupuli/puppet-lint-exec_idempotency-check'
   spec.license     = 'Apache-2.0'
   spec.author      = 'Vox Pupuli'


### PR DESCRIPTION
There was never a release in the past, so we should start with 1.0.0, not 2.0.0.