### PR TITLE
Refactor and add some more tests

### DIFF
--- a/spec/puppet-lint/plugins/check_exec_idempotency/check_exec_idempotency_spec.rb
+++ b/spec/puppet-lint/plugins/check_exec_idempotency/check_exec_idempotency_spec.rb
@@ -8,19 +8,21 @@ describe 'exec_idempotency' do
   context 'with fix disabled' do
     context 'correct exec resource declarations' do
       let(:code) do
-        <<-EOS_WITHOUT_FAILURES
-        exec { '/bin/touch /tmp/test':
-          creates => '/tmp/test',
-        }
-        exec { '/bin/foo':
-          unless => '/bin/false',
-        }
-        exec { '/bin/bar':
-          onlyif => '/bin/true',
-        }
-        exec { '/bin/baz':
-          refreshonly => true,
-        }
+        <<~EOS_WITHOUT_FAILURES
+          exec { '/bin/touch /tmp/test':
+            timeout => 10,
+            creates => '/tmp/test',
+          }
+          exec { '/bin/foo':
+            unless => '/bin/false',
+            tries  => 5,
+          }
+          exec { '/bin/bar':
+            onlyif => '/bin/true',
+          }
+          exec { '/bin/baz':
+            refreshonly => true,
+          }
         EOS_WITHOUT_FAILURES
       end
 
@@ -31,8 +33,8 @@ describe 'exec_idempotency' do
 
     context 'wrong exec resource declarations' do
       let(:code) do
-        <<-EOS_WITH_FAILURES
-        exec { '/bin/apt update': }
+        <<~EOS_WITH_FAILURES
+          exec { '/bin/apt update': }
         EOS_WITH_FAILURES
       end
 
@@ -41,7 +43,120 @@ describe 'exec_idempotency' do
       end
 
       it 'creates a warning' do
-        expect(problems).to contain_warning(msg).on_line(1).in_column(33)
+        expect(problems).to contain_warning(msg).on_line(1).in_column(25)
+      end
+    end
+
+    context 'with unless used in an attribute value' do
+      let(:code) do
+        <<~CODE
+          exec { '/bin/touch /tmp/test':
+            environment => unless $facts['kernel'] == 'Linux' { ['HOME=/opt/root'] }
+          }
+        CODE
+      end
+
+      it 'detects problems' do
+        expect(problems.size).to eq(1)
+      end
+    end
+
+    context 'with other resources' do
+      let(:code) do
+        <<~CODE
+          notify { 'test': }
+        CODE
+      end
+
+      it 'detects no problems' do
+        expect(problems.size).to eq(0)
+      end
+    end
+
+    context 'with idempotent attribute on single line' do
+      let(:code) do
+        <<~CODE
+          exec { '/bin/touch /tmp/test': creates => '/tmp/test' }
+        CODE
+      end
+
+      it 'detects no problems' do
+        expect(problems.size).to eq(0)
+      end
+    end
+
+    context 'with multiple `;` separated resource bodies including non idempotent resources' do
+      let(:code) do
+        <<~CODE
+          exec {
+            '/bin/touch /tmp/test':
+              creates => '/tmp/test'
+            ;
+            '/bin/touch /tmp/test2':
+            ;
+            '/bin/touch /tmp/test3':
+              environment => ['HOME=/root'],
+            ;
+            '/bin/touch /tmp/test4':
+              refreshonly => true,#{' '}
+            ;
+          }
+        CODE
+      end
+
+      it 'detects resources that aren\'t idempotent' do
+        expect(problems.size).to eq(2)
+      end
+    end
+
+    context 'with multiple `;` separated resource bodies including a single non idempotent resources' do
+      let(:code) do
+        <<~CODE
+          exec {
+            '/bin/touch /tmp/test':
+              creates => '/tmp/test'
+            ;
+            '/bin/touch /tmp/test3':
+              environment => ['HOME=/root'],
+            ;
+            '/bin/touch /tmp/test4':
+              refreshonly => true,#{' '}
+            ;
+          }
+        CODE
+      end
+
+      it 'detects resources that aren\'t idempotent' do
+        expect(problems.size).to eq(1)
+      end
+
+      it 'creates a warning' do
+        expect(problems).to contain_warning(msg).on_line(5).in_column(26)
+      end
+    end
+
+    context 'with resource defaults containing idempotent attribute and a separate non idempotent exec' do
+      let(:code) do
+        <<~CODE
+          exec {
+            default:
+              refreshonly => true,
+            ;
+            '/bin/touch /tmp/idempotent':
+            ;
+            '/bin/touch /tmp/idempotent2':
+            ;
+          }
+
+          exec { '/bin/touch /tmp/not_idempotent': }
+        CODE
+      end
+
+      it 'detects just one problem' do
+        pending(
+          'Detecting whether an exec resource falls inside a resource declarion with default attributes is difficult and currently not supported',
+        )
+        expect(problems.size).to eq(1)
       end
     end
   end


### PR DESCRIPTION
The previous implementation was relying on a bug in `puppet-lint` not being fixed. This replacement should continue to work after it's fixed.

(We could choose to simplify the logic in this check if we depended on the fixed version; but there would be no immediate pressure to do so.)

The `exec_attributes` helper should be a bit more robust too.  We only consider tokens that appear before the `=>` token as attributes. This prevents the possibility of mistaking an `unless` inside an expression assigned to an attribute as the `unless` attribute itself. A new test covers this.

`next_token_of` will also skip over `{ } blocks` by default. (I don't think the `Exec` type actually has any attribute that accepts a hash value, but this would prevent confusing those hash keys as resource attributes.)

I've included one `pending` test that shows a current limitation. The logic to cover this is probably too complex to be worth implementing, and there are still other cases that we will never be able to cover with the way puppet-lint manifest parsing works. (eg. if you set one or more idempotency attributes via the special splat attribute that references a variable).